### PR TITLE
typo: initla -> initial

### DIFF
--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -418,7 +418,7 @@
         "description": "API access",
         "price": "€1",
         "features": [
-          "€5 initla wallet credits",
+          "€5 initial wallet credits",
           "Pay as you go (listpris)",
           "Tillgång till alla modeller",
           "Community support",


### PR DESCRIPTION
This pull request includes a minor correction to a typo in the Swedish translation file.

* [`public/locales/sv/translation.json`](diffhunk://#diff-c96cb8d957a936fda7ee4154f9f8ec7cead4556dd4424b91e22a3468156e60f6L421-R421): Fixed a typo in the "features" section by changing "initla" to "initial" in the phrase "€5 initial wallet credits."