### PR TITLE
refactor: replace configuration-snippet with custom-headers ConfigMap

### DIFF
--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -6,14 +6,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/ssl-redirect: 'true'
-    # nginx.ingress.kubernetes.io/configuration-snippet: |
-    #   more_set_headers "Content-Security-Policy: default-src 'self'; script-src 'self' https://*.berget.ai; style-src 'self' https://*.berget.ai; font-src 'self' https://*.berget.ai; img-src 'self' https://*.berget.ai data:; connect-src 'self' https://*.berget.ai https://api.berget.ai; base-uri 'self'; form-action 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; worker-src 'self'; manifest-src 'self'; upgrade-insecure-requests;";
-    #   more_set_headers "X-Content-Type-Options: nosniff";
-    #   more_set_headers "X-Frame-Options: DENY";
-    #   more_set_headers "X-Xss-Protection: 0";
-    #   more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains; preload";
-    #   more_set_headers "Cross-Origin-Resource-Policy: same-site";
-    #   more_set_headers "Referrer-Policy: strict-origin";
+    nginx.ingress.kubernetes.io/custom-headers: berget-web/berget-custom-headers-configmap
 spec:
   ingressClassName: nginx
   tls:
@@ -34,6 +27,20 @@ spec:
                 name: berget-website
                 port:
                   number: 80
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: berget-custom-headers-configmap
+  namespace: berget-web
+data:
+  Content-Security-Policy: "default-src 'self'; script-src 'self' https://*.berget.ai; style-src 'self' https://*.berget.ai; font-src 'self' https://*.berget.ai; img-src 'self' https://*.berget.ai data:; connect-src 'self' https://*.berget.ai https://api.berget.ai; base-uri 'self'; form-action 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; worker-src 'self'; manifest-src 'self'; upgrade-insecure-requests;"
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: "0"
+  Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
+  Cross-Origin-Resource-Policy: same-site
+  Referrer-Policy: strict-origin
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress


### PR DESCRIPTION
This pull request introduces changes to the Kubernetes ingress configuration to improve the management of custom headers by replacing inline annotations with a `ConfigMap`. The most important changes include removing the inline header configuration and creating a `ConfigMap` to centralize and simplify header management.

### Changes to header management:

* [`k8s/ingress.yaml`](diffhunk://#diff-b631c9ffd19cadfcf3c44e986a61c04af9fb74458868351c8ec291067f7736a2L9-R9): Removed the inline `nginx.ingress.kubernetes.io/configuration-snippet` annotation and replaced it with `nginx.ingress.kubernetes.io/custom-headers` pointing to a `ConfigMap`. This simplifies header management and improves maintainability.
* [`k8s/ingress.yaml`](diffhunk://#diff-b631c9ffd19cadfcf3c44e986a61c04af9fb74458868351c8ec291067f7736a2R31-R44): Added a new `ConfigMap` named `berget-custom-headers-configmap` in the `berget-web` namespace to store custom headers, including `Content-Security-Policy`, `Strict-Transport-Security`, and other security-related headers.