### PR TITLE
feat: lägg till X-Permitted-Cross-Domain-Policies header för ökad säk…

### DIFF
--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -25,4 +25,5 @@ data:
   Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
   X-Content-Type-Options: "nosniff"
   X-Frame-Options: "DENY"
+  X-Permitted-Cross-Domain-Policies: "none"
   X-Xss-Protection: "0"

--- a/k8s/overlays/production/ingress-patch.yaml
+++ b/k8s/overlays/production/ingress-patch.yaml
@@ -34,6 +34,7 @@ data:
   Content-Security-Policy: "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.berget.ai; base-uri 'self'; form-action 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; worker-src 'self'; manifest-src 'self'; upgrade-insecure-requests;"
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
+  X-Permitted-Cross-Domain-Policies: none
   X-Xss-Protection: '0'
   Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
   Cross-Origin-Resource-Policy: same-site

--- a/k8s/overlays/stage/ingress-patch.yaml
+++ b/k8s/overlays/stage/ingress-patch.yaml
@@ -31,6 +31,7 @@ data:
   Content-Security-Policy: "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.stage.berget.ai; base-uri 'self'; form-action 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; worker-src 'self'; manifest-src 'self'; upgrade-insecure-requests;"
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
+  X-Permitted-Cross-Domain-Policies: none
   X-Xss-Protection: '0'
   Strict-Transport-Security: 'max-age=31536000; includeSubDomains; preload'
   Cross-Origin-Resource-Policy: same-site


### PR DESCRIPTION
This pull request adds the `X-Permitted-Cross-Domain-Policies` security header to all ingress configurations across base, production, and stage environments. This header helps prevent Adobe Flash and Acrobat from loading data from your site in potentially unsafe ways, further strengthening your application's security posture.

Security improvements:

* Added `X-Permitted-Cross-Domain-Policies: "none"` to the `k8s/base/ingress.yaml` file to enforce the policy at the base level.
* Added `X-Permitted-Cross-Domain-Policies: none` to the `k8s/overlays/production/ingress-patch.yaml` file for the production environment.
* Added `X-Permitted-Cross-Domain-Policies: none` to the `k8s/overlays/stage/ingress-patch.yaml` file for the staging environment.