### PR TITLE
Fix/owasp headers

### DIFF
--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -25,4 +25,5 @@ data:
   Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
   X-Content-Type-Options: "nosniff"
   X-Frame-Options: "DENY"
+  X-Permitted-Cross-Domain-Policies: "none"
   X-Xss-Protection: "0"

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -20,6 +20,8 @@ metadata:
   namespace: berget-web
 data:
   Content-Security-Policy: "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.berget.ai; base-uri 'self'; form-action 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; worker-src 'self'; manifest-src 'self'; upgrade-insecure-requests;"
+  Cross-Origin-Embedder-Policy: "require-corp"
+  Cross-Origin-Opener-Policy: "same-origin"
   Cross-Origin-Resource-Policy: "same-site"
   Referrer-Policy: "strict-origin"
   Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"

--- a/k8s/overlays/production/ingress-patch.yaml
+++ b/k8s/overlays/production/ingress-patch.yaml
@@ -34,6 +34,7 @@ data:
   Content-Security-Policy: "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.berget.ai; base-uri 'self'; form-action 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; worker-src 'self'; manifest-src 'self'; upgrade-insecure-requests;"
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
+  X-Permitted-Cross-Domain-Policies: none
   X-Xss-Protection: '0'
   Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
   Cross-Origin-Resource-Policy: same-site

--- a/k8s/overlays/production/ingress-patch.yaml
+++ b/k8s/overlays/production/ingress-patch.yaml
@@ -32,10 +32,12 @@ metadata:
   namespace: berget-web
 data:
   Content-Security-Policy: "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.berget.ai; base-uri 'self'; form-action 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; worker-src 'self'; manifest-src 'self'; upgrade-insecure-requests;"
+  Cross-Origin-Embedder-Policy: require-corp
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Resource-Policy: same-site
+  Referrer-Policy: strict-origin
+  Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   X-Permitted-Cross-Domain-Policies: none
   X-Xss-Protection: '0'
-  Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
-  Cross-Origin-Resource-Policy: same-site
-  Referrer-Policy: strict-origin

--- a/k8s/overlays/stage/ingress-patch.yaml
+++ b/k8s/overlays/stage/ingress-patch.yaml
@@ -31,6 +31,7 @@ data:
   Content-Security-Policy: "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.stage.berget.ai; base-uri 'self'; form-action 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; worker-src 'self'; manifest-src 'self'; upgrade-insecure-requests;"
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
+  X-Permitted-Cross-Domain-Policies: none
   X-Xss-Protection: '0'
   Strict-Transport-Security: 'max-age=31536000; includeSubDomains; preload'
   Cross-Origin-Resource-Policy: same-site

--- a/k8s/overlays/stage/ingress-patch.yaml
+++ b/k8s/overlays/stage/ingress-patch.yaml
@@ -29,10 +29,12 @@ metadata:
   namespace: berget-web
 data:
   Content-Security-Policy: "default-src 'self'; script-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; connect-src 'self' https://api.stage.berget.ai; base-uri 'self'; form-action 'self'; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; worker-src 'self'; manifest-src 'self'; upgrade-insecure-requests;"
+  Cross-Origin-Embedder-Policy: require-corp
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Resource-Policy: same-site
+  Referrer-Policy: strict-origin
+  Strict-Transport-Security: 'max-age=31536000; includeSubDomains; preload'
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   X-Permitted-Cross-Domain-Policies: none
   X-Xss-Protection: '0'
-  Strict-Transport-Security: 'max-age=31536000; includeSubDomains; preload'
-  Cross-Origin-Resource-Policy: same-site
-  Referrer-Policy: strict-origin


### PR DESCRIPTION
This pull request updates the security headers in the ingress configuration files for all environments (base, production, and stage). The main goal is to strengthen the application's security posture by adding and standardizing several important HTTP security headers.

Key security header updates:

**Addition of new security headers:**

* Added `Cross-Origin-Embedder-Policy` (`require-corp`) and `Cross-Origin-Opener-Policy` (`same-origin`) to help prevent cross-origin attacks and enable advanced browser security features. [[1]](diffhunk://#diff-69f06cb699db502abadf560de482bba252396f0096bb3b8cda3aa9c7b815d499R23-R30) [[2]](diffhunk://#diff-2eaedfbb2b918c62cf0a1a0481f2f67b7d3162f3f413dc9bd5b6329779508083R32-L37) [[3]](diffhunk://#diff-1ebb29a7116568eb79d16e9705d1e189ca8e2f4152dd373ca319338cd08c9d74R35-L40)
* Added `X-Permitted-Cross-Domain-Policies` (`none`) to restrict Adobe Flash and Acrobat cross-domain data loading. [[1]](diffhunk://#diff-69f06cb699db502abadf560de482bba252396f0096bb3b8cda3aa9c7b815d499R23-R30) [[2]](diffhunk://#diff-2eaedfbb2b918c62cf0a1a0481f2f67b7d3162f3f413dc9bd5b6329779508083R32-L37) [[3]](diffhunk://#diff-1ebb29a7116568eb79d16e9705d1e189ca8e2f4152dd373ca319338cd08c9d74R35-L40)

**Standardization and reordering of existing headers:**

* Ensured `Strict-Transport-Security`, `Cross-Origin-Resource-Policy`, and `Referrer-Policy` are included and consistently ordered across all environment overlays. [[1]](diffhunk://#diff-2eaedfbb2b918c62cf0a1a0481f2f67b7d3162f3f413dc9bd5b6329779508083R32-L37) [[2]](diffhunk://#diff-1ebb29a7116568eb79d16e9705d1e189ca8e2f4152dd373ca319338cd08c9d74R35-L40)

These changes help enforce stricter browser security policies and reduce the risk of cross-origin and cross-domain vulnerabilities.