### PR TITLE
fix: uppdatera ingress-portar från nummer till namn för berget-webbplats

### DIFF
--- a/k8s/overlays/production/ingress-redirects.yaml
+++ b/k8s/overlays/production/ingress-redirects.yaml
@@ -39,7 +39,7 @@ spec:
               service:
                 name: berget-website
                 port:
-                  number: 80
+                  name: http
     - host: www.berget.cloud
       http:
         paths:
@@ -49,4 +49,4 @@ spec:
               service:
                 name: berget-website
                 port:
-                  number: 80
+                  name: http


### PR DESCRIPTION
This pull request makes a small configuration update to the Kubernetes ingress resource for the production environment. The change updates the service port reference from a numeric value to a named port, which can help improve clarity and compatibility.

* Changed the service port reference from `number: 80` to `name: http` in the `k8s/overlays/production/ingress-redirects.yaml` file. [[1]](diffhunk://#diff-a423b11d501054f977ce20b7f125f0422bede8e33d2578e7629e40f6250b3611L42-R42) [[2]](diffhunk://#diff-a423b11d501054f977ce20b7f125f0422bede8e33d2578e7629e40f6250b3611L52-R52)